### PR TITLE
Add: i18nによる日本語化対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+gem 'rails-i18n', '~> 7.0.0'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.8.4)
       actionpack (= 7.0.8.4)
       activesupport (= 7.0.8.4)
@@ -229,6 +232,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.8, >= 7.0.8.4)
+  rails-i18n (~> 7.0.0)
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="bg-green-100 py-4 text-center">
   <div class="flex justify-center space-x-4">
-    <%= link_to 'お問い合わせ', '#', class: 'text-green-700' %>
-    <%= link_to '利用規約', '#', class: 'text-green-700' %>
-    <%= link_to 'プライバシーポリシー', '#', class: 'text-green-700' %>
+    <%= link_to t('footer.inquiry'), '#', class: 'text-green-700' %>
+    <%= link_to t('footer.agreement'), '#', class: 'text-green-700' %>
+    <%= link_to t('footer.privacy_policy'), '#', class: 'text-green-700' %>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="bg-green-100 flex justify-between items-center p-4">
   <h1 class="text-2xl font-semibold text-center mx-auto">えんつむぎ</h1>
   <div class="flex space-x-4">
-    <%= link_to 'ユーザー登録', '#', class: 'btn btn-outline' %>
-    <%= link_to 'ログイン', '#', class: 'btn btn-outline' %>
+    <%= link_to t('header.signin'), '#', class: 'btn btn-outline' %>
+    <%= link_to t('header.login'), '#', class: 'btn btn-outline' %>
   </div>
 </header>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module Myapp
       g.helper false #ヘルパーファイルを自動生成しないようにする
       g.test_framework nil #テストフレームワークを使わないようにする
     end
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        email: メールアドレス
+        last_name: 姓
+        first_name: 名
+        password: パスワード
+        password_confirmation: パスワード確認

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  header:
+    signin: ユーザー登録
+    login: ログイン
+  footer:
+    inquiry: お問い合わせ
+    agreement: 利用規約
+    privacy_policy: プライバシーポリシー

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end


### PR DESCRIPTION
### 概要
i18nによる日本語設定をした

### 内容

- [x] gemのインストール
- [x] `config/application.rb`にデフォルトの言語を日本語にする設定を追加
- [x] `config/locales/activerecord/ja.yml`を作成
- [x] `config/locales/views/ja.yml`を作成
- [x] ヘッダーとフッターの日本語部分をi18nに対応させる