### PR TITLE
Add: 検索ページにマップ表示

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./maps"

--- a/app/javascript/maps.js
+++ b/app/javascript/maps.js
@@ -1,0 +1,14 @@
+document.addEventListener("DOMContentLoaded", function() {
+  function initMap() {
+    const mapOptions = {
+      center: { lat: 35.6895, lng: 139.6917 }, // 東京の座標
+      zoom: 10
+    };
+    const mapElement = document.getElementById("map");
+    if (mapElement) {
+      const map = new google.maps.Map(mapElement, mapOptions);
+    }
+  }
+
+  window.initMap = initMap;
+});

--- a/app/views/shrines/index.html.erb
+++ b/app/views/shrines/index.html.erb
@@ -25,11 +25,9 @@
     </div>
 
     <!-- Map container -->
-    <div class="w-3/4 p-4">
-      <div class="bg-blue-200 h-96 w-full rounded-lg flex items-center justify-center">
-        <p>Google Maps APIでマップを表示</p>
-      </div>
+    <div id="map" style="height: 500px; width: 100%;">
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_JAVASCRIPT_API_KEY'] %>&callback=initMap"></script>
     </div>
+    <%= javascript_include_tag 'application' %>
   </div>
 </div>
-<%= javascript_include_tag 'application' %>


### PR DESCRIPTION
### 概要
Google Maps JavaScript APIを用いて検索ページにマップを表示する

### 内容

- [x] ` app/javascript/map.js`を作成し、マップの初期化を行う関数を定義する
- [x] `map.js`を`application.js`で読み込む
- [x] マップを表示するviewファイルにscriptタグを追加
- [x] サーバー再起動してブラウザで確認

### 備考
関連issue：[Google Maps APIキーの取得 #55 ](https://github.com/akane-5/entsumugi/issues/55)にて対応済み
- [x] Google APIキーの取得
- [x] 環境変数の設定