### PR TITLE
Add: 神社データを収集するためサービスクラスとRakeタスクを作成

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
 && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim postgresql-client
 
 WORKDIR /myapp
 

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'ransack'
 
 gem 'dotenv-rails'
 
+gem 'google-places'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -107,6 +108,11 @@ GEM
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-places (1.0.0)
+      activesupport
+      httparty (~> 0.14.0)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -133,6 +139,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     net-imap (0.4.14)
       date
       net-protocol
@@ -258,6 +266,7 @@ DEPENDENCIES
   devise-i18n
   devise-i18n-views
   dotenv-rails
+  google-places
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/models/shrine.rb
+++ b/app/models/shrine.rb
@@ -1,6 +1,13 @@
 class Shrine < ApplicationRecord
   belongs_to :prefecture
 
+  validates :name, presence: true
+  validates :address, presence: true
+  validates :latitude, presence: true, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
+  validates :longitude, presence: true, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :place_id, presence: true, uniqueness: true
+  validates :photo_url, allow_blank: true
+
   def self.ransackable_attributes(auth_object = nil)
     ["prefecture_id","name",]
   end

--- a/app/services/fetch_shrines_data.rb
+++ b/app/services/fetch_shrines_data.rb
@@ -1,0 +1,60 @@
+require 'google_places'
+
+class FetchShrinesData
+  REGIONS = {
+    hokkaido: { lat: 43.06417, lng: 141.34694, name: '北海道' },
+    tohoku:   { lat: 38.26889, lng: 140.86917, name: '東北地方' },
+    kanto:    { lat: 35.68944, lng: 139.69167, name: '関東地方' },
+    chubu:    { lat: 36.65139, lng: 138.18111, name: '中部地方' },
+    kinki:    { lat: 34.68639, lng: 135.52, name: '近畿地方' },
+    chugoku:  { lat: 34.39639, lng: 132.45944, name: '中国地方' },
+    shikoku:  { lat: 34.06583, lng: 134.55944, name: '四国地方' },
+    kyushu:   { lat: 33.59028, lng: 130.40167, name: '九州地方' }
+  }
+
+  def initialize
+    @client = GooglePlaces::Client.new(ENV['PLACES_API_KEY'])
+  end
+
+  def fetch_and_save_shrines
+    query = '御朱印 神社'
+    language = 'ja'
+    radius = 50000 # 半径50km
+
+    REGIONS.each do |key, region|
+      puts "Fetching data for #{region[:name]}"
+      fetch_spots(region[:lat], region[:lng], query, language, radius)
+    end
+  end
+
+  private
+
+  def fetch_spots(lat, lng, query, language, radius)
+    spots = @client.spots(lat, lng, radius: radius, language: language, types: ['shrine'])
+    save_spots(spots)
+
+    # ページネーションの処理
+    while spots.next_page_token do
+      sleep 2 # 次のリクエストまで少し待つ
+      spots = @client.spots(lat, lng, radius: radius, language: language, types: ['shrine'], page_token: spots.next_page_token)
+      save_spots(spots)
+    end
+  end
+
+  def save_spots(spots)
+    spots.each do |spot|
+      shrine = Shrine.find_or_initialize_by(place_id: spot.place_id)
+      shrine.name = spot.name
+      shrine.address = spot.vicinity
+      shrine.latitude = spot.lat
+      shrine.longitude = spot.lng
+      shrine.photo_url = spot.photos.first.photo_url if spot.photos.any?
+
+      if shrine.save
+        puts "「#{shrine.name}」を保存しました"
+      else
+        puts "「#{spot.name}」の保存に失敗しました: #{shrine.errors.full_messages.join(', ')}"
+      end
+    end
+  end
+end

--- a/db/migrate/20240717012924_addaddress_toshrines.rb
+++ b/db/migrate/20240717012924_addaddress_toshrines.rb
@@ -1,0 +1,11 @@
+class AddaddressToshrines < ActiveRecord::Migration[7.0]
+  def change
+    add_column :shrines, :address, :string, null: false
+    add_column :shrines, :latitude, :float, null: false
+    add_column :shrines, :longitude, :float, null: false
+    add_column :shrines, :place_id, :string, null: false, unique: true
+    add_column :shrines, :photo_url, :string
+
+    add_index :shrines, :place_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_08_151821) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_17_012924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_08_151821) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "prefecture_id"
+    t.string "address", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
+    t.string "place_id", null: false
+    t.string "photo_url"
+    t.index ["place_id"], name: "index_shrines_on_place_id", unique: true
     t.index ["prefecture_id"], name: "index_shrines_on_prefecture_id"
   end
 

--- a/lib/tasks/fetch_shrines.rake
+++ b/lib/tasks/fetch_shrines.rake
@@ -1,0 +1,6 @@
+namespace :fetch do
+  desc "Google Places APIから神社データを取得"
+  task shrines: :environment do
+    FetchShrinesData.new.fetch_and_save_shrines
+  end
+end


### PR DESCRIPTION
### 概要
Google Places APIを用いて神社データを収集するため、サービスクラスとRakeタスクを作成

### 内容

- [x] gemインストール
- [x] shrinesテーブルに必要カラムを追加
- [x] Shrineモデルにバリデーション設定
- [x] サービスクラスを作成し、API呼び出しのロジックを記述
- [x] Rakeタスクを作成

### 備考
関連issue：[Google Maps APIキーの取得 #55 ](https://github.com/akane-5/entsumugi/issues/55)にて対応済み
- [x] Google APIキーの取得
- [x] 環境変数の設定