### PR TITLE
Add: 検索結果一覧ページの作成

### DIFF
--- a/app/controllers/shrines_controller.rb
+++ b/app/controllers/shrines_controller.rb
@@ -1,6 +1,10 @@
 class ShrinesController < ApplicationController
+  def search
+    @q = Shrine.ransack(params[:q])
+  end
+
   def index
     @q = Shrine.ransack(params[:q])
-    @shrines = @q.result.includes(:prefecture)
+    @shrines = @q.result
   end
 end

--- a/app/views/shrines/index.html.erb
+++ b/app/views/shrines/index.html.erb
@@ -1,33 +1,17 @@
-
 <div class="container mx-auto py-4">
-  <div class="flex">
-    <!-- Sidebar for search options -->
-    <div class="w-1/4 p-4 bg-green-200 rounded-lg">
-      <%= search_form_for @q, url: shrines_path, method: :get do |f| %>
-        <div class="mb-4">
-          <%= f.label :prefecture_id, '都道府県', class: 'block text-gray-700 font-bold mb-2' %>
-          <%= f.collection_select :prefecture_id_eq, Prefecture.all, :id, :name, { include_blank: '選択する' }, class: 'block w-full bg-white border border-gray-300 rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-gray-500' %>
+  <h1 class="text-2xl font-bold mb-4">LIST</h1>
+  <div class="flex flex-wrap justify-center">
+    <% @shrines.each do |shrine| %>
+      <div class="max-w-sm rounded overflow-hidden shadow-lg m-4 bg-white">
+        <div class="px-6 py-4">
+          <div class="font-bold text-xl mb-2"><%= shrine.name %></div>
+          <img class="w-full h-48 object-cover" src="<%= shrine.photo_reference %>" alt="<%= shrine.name %>の写真">
+          <p class="text-gray-700 text-base"><%= shrine.address %></p>
         </div>
-        <div class="mb-4">
-          <label class="block text-gray-700 font-bold mb-2">カテゴリ</label>
-          <button class="block w-full bg-yellow-300 text-black font-bold py-2 px-3 rounded mb-2">金運</button>
-          <button class="block w-full bg-pink-300 text-black font-bold py-2 px-3 rounded mb-2">恋愛運</button>
-          <button class="block w-full bg-green-300 text-black font-bold py-2 px-3 rounded">健康運</button>
+        <div class="px-6 pt-4 pb-2">
+          <%= link_to '詳細', '#', class: 'bg-green-500 text-white font-bold py-2 px-4 rounded' %>
         </div>
-        <div class="mb-4">
-          <%= f.label :name_cont, 'フリーワード', class: 'block text-gray-700 font-bold mb-2' %>
-          <%= f.text_field :name_cont, placeholder: '神社仏閣名など', class: 'block w-full bg-white border border-gray-300 rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-gray-500' %>
-        </div>
-        <div class="actions">
-          <%= f.submit '検索', class: 'block w-full bg-green-500 text-white font-bold py-2 px-4 rounded cursor-pointer' %>
-        </div>
-      <% end %>
-    </div>
-
-    <!-- Map container -->
-    <div id="map" style="height: 500px; width: 100%;">
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_JAVASCRIPT_API_KEY'] %>&callback=initMap"></script>
-    </div>
-    <%= javascript_include_tag 'application' %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shrines/search.html.erb
+++ b/app/views/shrines/search.html.erb
@@ -1,0 +1,32 @@
+<div class="container mx-auto py-4">
+  <div class="flex">
+    <!-- Sidebar for search options -->
+    <div class="w-1/4 p-4 bg-green-200 rounded-lg">
+      <%= search_form_for @q, url: shrines_path, method: :get, data: { turbo: false } do |f| %>
+        <div class="mb-4">
+          <%= f.label :prefecture_id, '都道府県', class: 'block text-gray-700 font-bold mb-2' %>
+          <%= f.collection_select :prefecture_id_eq, Prefecture.all, :id, :name, { include_blank: '選択する' }, class: 'block w-full bg-white border border-gray-300 rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-gray-500' %>
+        </div>
+        <div class="mb-4">
+          <label class="block text-gray-700 font-bold mb-2">カテゴリ</label>
+          <button class="block w-full bg-yellow-300 text-black font-bold py-2 px-3 rounded mb-2">金運</button>
+          <button class="block w-full bg-pink-300 text-black font-bold py-2 px-3 rounded mb-2">恋愛運</button>
+          <button class="block w-full bg-green-300 text-black font-bold py-2 px-3 rounded">健康運</button>
+        </div>
+        <div class="mb-4">
+          <%= f.label :name_cont, 'フリーワード', class: 'block text-gray-700 font-bold mb-2' %>
+          <%= f.text_field :name_cont, placeholder: '神社名など', class: 'block w-full bg-white border border-gray-300 rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-gray-500' %>
+        </div>
+        <div class="actions">
+          <%= f.submit '検索', class: 'block w-full bg-green-500 text-white font-bold py-2 px-4 rounded cursor-pointer' %>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- Map container -->
+    <div id="map" style="height: 500px; width: 100%;">
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_JAVASCRIPT_API_KEY'] %>&callback=initMap"></script>
+    </div>
+    <%= javascript_include_tag 'application' %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,9 @@ Rails.application.routes.draw do
   # root "articles#index"
   root "static_pages#index"
 
-  resources :shrines, only: [:index]
+  resources :shrines, only: [:index] do
+    collection do
+      get 'search'
+    end
+  end
 end


### PR DESCRIPTION
### 概要
検索結果一覧ページを作成し、フォームの検索ボタンから遷移するようにした

### 内容

- [x] 検索ロジックをindexアクション→searchアクションに修正
- [x] 検索フォームを`index.html.erb`→`search.html.erb`に修正
- [x] ルーティングの設定
- [x] shrinesコントローラーのindexアクションに検索結果の一覧表示を設定
- [x] `shrines/index.html.erb`に検索結果一覧ページのviewを設定
- [x] フォームの検索ボタンから検索結果一覧ページに遷移するように設定