### PR TITLE
Fix: 神社の写真が表示されるように修正

### DIFF
--- a/app/models/shrine.rb
+++ b/app/models/shrine.rb
@@ -12,4 +12,13 @@ class Shrine < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["prefecture_id","name",]
   end
+
+  # photo_referenceからURLを取得するメソッド
+  def formatted_photo_reference
+    # JSON形式からURLを取り出す
+    urls = JSON.parse(photo_reference)
+    # 最初のURLを取り出してエスケープ解除
+    image_url = urls.first.gsub('\u0026', '&') if urls.any?
+    image_url
+  end
 end

--- a/app/views/shrines/index.html.erb
+++ b/app/views/shrines/index.html.erb
@@ -4,7 +4,7 @@
     <% @shrines.each do |shrine| %>
       <div class="card bg-white max-w-sm shadow m-4">
         <figure>
-          <img src="<%= shrine.photo_reference %>" alt="<%= shrine.name %>の写真">
+          <img src="<%= shrine.formatted_photo_reference %>" alt="<%= shrine.name %>の写真" class="w-full h-auto max-h-60 object-cover">
         </figure>
         <div class="card-body">
           <div class="card-title"><%= shrine.name %></div>

--- a/app/views/shrines/show.html.erb
+++ b/app/views/shrines/show.html.erb
@@ -1,15 +1,17 @@
-<div class="container mx-auto py-4">
-  <div class="bg-gray-100 p-4 rounded-lg">
+<div class="container mx-auto pt-12 pb-8 ">
+  <div class="bg-gray-100 p-4 w-9/12 h-1/4 rounded-lg mx-auto">
     <div class="flex items-center">
-      <div class="w-3/4">
-        <h2 class="text-2xl font-bold mb-2"><%= @shrine.name %></h2>
-        <div class="flex mb-2">
-          <span class="bg-yellow-300 text-black font-bold py-1 px-2 rounded mr-2">金運</span>
-          <span class="bg-pink-300 text-black font-bold py-1 px-2 rounded mr-2">恋愛運</span>
-          <span class="bg-green-300 text-black font-bold py-1 px-2 rounded">健康運</span>
-        </div>
-        <p class="text-gray-700 mb-2"><%= @shrine.address %></p>
-        <p class="text-gray-700 mb-2">
+      <div class="w-2/5">
+        <% if @shrine.photo_reference.present? %>
+          <img src="<%= @shrine.formatted_photo_reference %>" alt="<%= @shrine.name %>" class="rounded-lg w-full h-52">
+        <% else %>
+          <div class="bg-gray-300 text-white p-4 rounded-lg">PHOTO</div>
+        <% end %>
+      </div>
+      <div class="w-3/5 ml-10">
+        <h2 class="text-2xl font-bold mt-2"><%= @shrine.name %></h2>
+        <p class="text-gray-700 mt-6"><%= @shrine.address %></p>
+        <p class="text-gray-700 mt-2">
           公式サイト: 
           <% if @shrine.website.present? %>
             <%= link_to @shrine.website, @shrine.website, target: '_blank', rel: 'noopener' %>
@@ -17,18 +19,18 @@
             -
           <% end %>
         </p>
-      </div>
-      <div class="w-1/4">
-        <% if @shrine.photo_reference.present? %>
-          <img src="<%= @shrine.photo_reference %>" alt="<%= @shrine.name %>" class="rounded-lg">
-        <% else %>
-          <div class="bg-gray-300 text-white p-4 rounded-lg">PHOTO</div>
-        <% end %>
+        <div class="flex mt-6">
+          <span class="bg-yellow-300 text-black font-bold py-1 px-2 rounded mr-2">金運</span>
+          <span class="bg-pink-300 text-black font-bold py-1 px-2 rounded mr-2">恋愛運</span>
+          <span class="bg-green-300 text-black font-bold py-1 px-2 rounded">健康運</span>
+        </div>
       </div>
     </div>
   </div>
+</div>
 
+<div class="container mx-auto pt-12 pb-8">
   <div class="mt-4">
-    <p class="text-gray-700">まだ投稿がありません</p>
+    <p class="text-gray-700 text-center">まだ投稿がありません</p>
   </div>
 </div>


### PR DESCRIPTION
### 概要
検索結果一覧ページと詳細ページの神社情報に写真が表示されない問題を修正

### 内容

- [x] Shrineモデルにphoto_referenceからURLを取得するメソッドを追加
- [x] `shrines/index.html.erb`と`shrines/show.html.erb`のimgタグの参照先を修正