### PR TITLE
Fix: 神社データの収集と保存のサービスクラスとタスクを修正

### DIFF
--- a/lib/tasks/fetch_shrines_prefecture.rake
+++ b/lib/tasks/fetch_shrines_prefecture.rake
@@ -2,10 +2,12 @@ namespace :fetch do
   desc "愛知県の神社データを保存"
   task shrines_aichi: :environment do
     api_key = ENV['PLACES_API_KEY']
-    prefecture_code = 'aichi'
     prefecture_name = '愛知県'
+    center_latitude = 35.1802 #緯度
+    center_longitude = 136.9066 #経度
+    radius = 50000 #半径50kmの例
 
-    fetch_shrines_data_prefecture = FetchShrinesDataPrefecture.new(api_key, prefecture_code, prefecture_name)
+    fetch_shrines_data_prefecture = FetchShrinesDataPrefecture.new(api_key, prefecture_name, center_latitude, center_longitude, radius)
     fetch_shrines_data_prefecture.fetch_and_save
 
     puts "#{prefecture_name}の神社データの取得と保存が完了しました！"
@@ -14,10 +16,40 @@ namespace :fetch do
   desc "岐阜県の神社データを保存"
   task shrines_gifu: :environment do
     api_key = ENV['PLACES_API_KEY']
-    prefecture_code = 'gifu'
     prefecture_name = '岐阜県'
+    center_latitude = 35.3912 #緯度
+    center_longitude = 136.7223 #経度
+    radius = 50000 #半径50kmの例
 
-    fetch_shrines_data_prefecture = FetchShrinesDataPrefecture.new(api_key, prefecture_code, prefecture_name)
+    fetch_shrines_data_prefecture = FetchShrinesDataPrefecture.new(api_key, prefecture_name, center_latitude, center_longitude, radius)
+    fetch_shrines_data_prefecture.fetch_and_save
+
+    puts "#{prefecture_name}の神社データの取得と保存が完了しました！"
+  end
+
+  desc "三重県の神社データを保存"
+  task shrines_mie: :environment do
+    api_key = ENV['PLACES_API_KEY']
+    prefecture_name = '三重県'
+    center_latitude = 34.7303 #緯度
+    center_longitude = 136.5086 #経度
+    radius = 50000 #半径50kmの例
+
+    fetch_shrines_data_prefecture = FetchShrinesDataPrefecture.new(api_key, prefecture_name, center_latitude, center_longitude, radius)
+    fetch_shrines_data_prefecture.fetch_and_save
+
+    puts "#{prefecture_name}の神社データの取得と保存が完了しました！"
+  end
+
+  desc "静岡県の神社データを保存"
+  task shrines_shizuoka: :environment do
+    api_key = ENV['PLACES_API_KEY']
+    prefecture_name = '静岡県'
+    center_latitude = 34.9769 #緯度
+    center_longitude = 138.3831 #経度
+    radius = 50000 #半径50kmの例
+
+    fetch_shrines_data_prefecture = FetchShrinesDataPrefecture.new(api_key, prefecture_name, center_latitude, center_longitude, radius)
     fetch_shrines_data_prefecture.fetch_and_save
 
     puts "#{prefecture_name}の神社データの取得と保存が完了しました！"


### PR DESCRIPTION
### 概要
神社データの収集をYAMLファイルを使わない方法に変更したことにより、サービスクラスとタスクを修正

### 内容
変更前：YAMLファイルに神社リストを作成し、サービスクラスで読み込んで、神社名が一致するデータを取得・保存
変更後：APIのリクエストクエリに都道府県名と範囲を指定してデータを取得・保存

- [x] サービスクラスを修正
- [x] Rakeタスクを修正