### PR TITLE
Add: ログイン後ヘッダーを作成

### DIFF
--- a/app/views/shared/_header_before_login.html.erb
+++ b/app/views/shared/_header_before_login.html.erb
@@ -5,20 +5,15 @@
     </div>
     <div class="flex-none">
       <ul class="menu menu-horizontal flex items-center">
-        <li></li>
+        <li><%= link_to 'ログイン', '#' %></li>
         <li>
           <details class="relative">
             <summary class="mr-2">
               メニュー
             </summary>
-            <ul class="bg-background px-1 py-2 rounded-md text-sm top-7 right-1 leading-normal w-40 z-10">
+            <ul class="bg-background px-1 py-2 rounded-md text-sm top-7 right-1 leading-relaxed w-40 z-10">
               <li><%= link_to '神社を探す', '#' %></li>
               <li><%= link_to '御朱印を投稿', '#' %></li>
-              <hr class="my-2 h-0.5 border-t-0 bg-neutral-100" />
-              <li><%= link_to 'マイページ', '#' %></li>
-              <li><%= link_to '投稿一覧', '#' %></li>
-              <li><%= link_to 'ブックマーク一覧', '#' %></li>
-              <li><%= link_to 'ログアウト', '#' %></li>
             </ul>
           </details>
         </li>


### PR DESCRIPTION
### 概要
ログイン前後でヘッダーの表示内容が変わるように、ログイン前ヘッダーとログイン後ヘッダーを作成

### 内容

- [x] `app/views/shared/_header_before_login.html.erb`を作成
- [x] `_header_before_login.html.erb`にログイン前ヘッダーを設定
- [x] `app/views/shared/_header.html.erb`をログイン後ヘッダーに修正