### PR TITLE
Add: プロフィール編集ページの作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -29,11 +29,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def update
   #   super
   # end
-
+  protected
   # パスワード以外はパスワードを入力しなくても更新できるようにする
   def update_resource(resource, params)
-    return super if params['password'].present?
-    resource.update_without_password(params.except('current_password'))
+    resource.update_without_password(params)
+  end
+
+  # プロフィール更新後のリダイレクト先を変更
+  def after_update_path_for(resource)
+    users_path
   end
 
   # DELETE /resource

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,4 +2,8 @@ class UsersController < ApplicationController
   def show
     @user = current_user
   end
+
+  def profile
+    render partial: 'profile'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, on: :create
   validates :uid, presence: true, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
   # omniauth_callbacks_controllerで使用

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,51 @@
-<h2><%= t('.title', resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'registrations.edit.title')) %></h2>
+<div class="flex justify-center">
+  <div class="flex flex-col items-center bg-base-100 mt-28 p-8 rounded-lg shadow-lg w-2/5">
+    <div class="mb-6">
+        <h2><%= t('.title', resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'registrations.edit.title')) %></h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <div class="w-full max-w-lg ">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+        <div class="form-control mb-2">
+          <label class="label pb-0"><span class="label-text"><%= f.label :name %></span></label>
+          <%= f.text_field :name, class: "w-full px-2 py-1 h-9 border rounded" %>
+        </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
-  <% end %>
+        <div class="form-control mb-2">
+          <label class="label pb-0"><span class="label-text"><%= f.label :email %></span></label>
+          <%= f.email_field :email, class: "w-full px-2 py-1 h-9 border rounded", autocomplete: "email" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-    <% end %>
-  </div>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+        <% end %>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+        <div class="form-control mb-2">
+          <label class="label pb-0"><span class="label-text"><%= f.label :password %><i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i></span></label>
+          <%= f.password_field :password, class: "w-full px-2 py-1 h-9 border rounded", autocomplete: "new-password" %>
+          <% if @minimum_password_length %>
+            <em class="text-end"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+          <% end %>
+        </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
+        <div class="form-control flex items-center mt-7">
+          <%= f.submit t('.update'), class: 'bg-navy text-white py-2 px-4 rounded w-32 text-center' %>
+        </div>
+      <% end %>
 
-  <div class="actions">
-    <%= f.submit t('.update') %>
-  </div>
-<% end %>
-
+<%
+=begin %>
 <h3><%= t('.cancel_my_account') %></h3>
 
 <div><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure'), turbo_confirm: t('.are_you_sure') }, method: :delete %></div>
+<%
+=end %>
 
-<%= link_to t('devise.shared.links.back'), :back %>
+      <div class="form-control flex items-center mt-4">
+        <%= link_to t('devise.shared.links.back'), :back %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
               <li><%= link_to '神社を探す', '#' %></li>
               <li><%= link_to '御朱印を投稿', '#' %></li>
               <hr class="my-2 h-0.5 border-t-0 bg-neutral-100" />
-              <li><%= link_to 'マイページ',  users_profile_path %></li>
+              <li><%= link_to 'マイページ', users_path %></li>
               <li><%= link_to '投稿一覧', '#' %></li>
               <li><%= link_to 'ブックマーク一覧', '#' %></li>
               <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %></li>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -1,0 +1,38 @@
+<div class="flex justify-center">
+  <div class="flex flex-col items-center bg-base-100 p-8 rounded-lg shadow-lg w-2/5">
+    <div class="avatar mb-6">
+      <div class="w-20 rounded-full">
+        <%= image_tag 'default_icon.png', alt: 'プロフィール画像' %>
+      </div>
+    </div>
+
+    <div class="w-full max-w-lg ">
+      <div class="form-control mb-2">
+        <label class="label pb-0"><span class="label-text">ユーザーネーム</span></label>
+        <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
+          <%= @user.name %>
+        </div>
+      </div>
+      <div class="form-control mb-2">
+        <label class="label pb-0"><span class="label-text">メールアドレス</span></label>
+        <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
+          <%= @user.email %>
+        </div>
+      </div>
+      <div class="form-control mb-2">
+        <label class="label pb-0"><span class="label-text">パスワード</span></label>
+        <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
+          <%= @user.password %>
+        </div>
+      </div>
+      <div class="form-control mb-6">
+        <label class="label pb-0"><span class="label-text">プロフィール画像</span></label>
+        <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
+        </div>
+      </div>
+      <div class="form-control flex items-center">
+        <%= link_to '編集する', edit_user_registration_path, data: { turbo: false }, class: 'bg-navy text-white py-2 px-4 rounded w-32 text-center' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,45 +11,8 @@
 
     <!-- コンテンツ部分（Turbo Frameで囲む） -->
     <%= turbo_frame_tag "content" do %>
-      <!-- 初期表示: アカウント設定フォーム -->
-      <div class="flex justify-center">
-        <div class="flex flex-col items-center bg-base-100 p-8 rounded-lg shadow-lg w-2/5">
-          <div class="avatar mb-6">
-            <div class="w-20 rounded-full">
-              <%= image_tag 'default_icon.png', alt: 'プロフィール画像' %>
-            </div>
-          </div>
-
-          <div class="w-full max-w-lg ">
-            <div class="form-control mb-2">
-              <label class="label pb-0"><span class="label-text">ユーザーネーム</span></label>
-              <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
-                <%= @user.name %>
-              </div>
-            </div>
-            <div class="form-control mb-2">
-              <label class="label pb-0"><span class="label-text">メールアドレス</span></label>
-              <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
-                <%= @user.email %>
-              </div>
-            </div>
-            <div class="form-control mb-2">
-              <label class="label pb-0"><span class="label-text">パスワード</span></label>
-              <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
-                <%= @user.password %>
-              </div>
-            </div>
-            <div class="form-control mb-6">
-              <label class="label pb-0"><span class="label-text">プロフィール画像</span></label>
-              <div class="input input-bordered w-full px-2 py-1 h-9 border rounded">
-              </div>
-            </div>
-            <div class="form-control flex items-center">
-              <%= link_to '編集する', '#', class: 'bg-navy text-white py-2 px-4 rounded w-32 text-center' %>
-            </div>
-          </div>
-        </div>
-      </div>
+      <!-- 初期表示: プロフィール -->
+      <%= render 'profile' %>
     <% end %>
   </div>
 </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -44,7 +44,7 @@ ja:
         are_you_sure: "本当に良いですか?"
         cancel_my_account: "アカウント削除"
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
-        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        leave_blank_if_you_don_t_want_to_change_it: "変更時のみ入力"
         title: "%{resource}編集"
         unhappy: "気に入りません"
         update: "更新"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get "users/profile" => "users#show"
+  resource :users, only: [:show] do
+    get 'profile', on: :collection
+  end
 end


### PR DESCRIPTION
### 概要
プロフィール編集ページを作成し、ユーザー名、メールアドレスの変更ができるようにする

### 内容

- [x] プロフィールページからプロフィール編集ページに遷移
- [x] プロフィール編集ページでユーザー名、メールアドレスの変更ができる
- [x] プロフィール変更時にパスワード入力なしで更新できるようにする